### PR TITLE
Align DynamicProxy-based avatars with the static one

### DIFF
--- a/src/Avatar.UnitTests/AvatarFactoryTests.cs
+++ b/src/Avatar.UnitTests/AvatarFactoryTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Avatars.UnitTests
@@ -26,6 +28,33 @@ namespace Avatars.UnitTests
 
             Assert.Same(instance, actual);
         }
+
+        [Fact]
+        public async Task ReplaceFactoryLocally()
+        {
+            var factory1 = new TestFactory(new object());
+            var factory2 = new TestFactory(new object());
+
+            await Task.WhenAll(
+                Task.Run(() =>
+                {
+                    AvatarFactory.LocalDefault = factory1;
+                    Thread.Sleep(50);
+                    Assert.Same(factory1, AvatarFactory.Default);
+                }),
+                Task.Run(() =>
+                {
+                    AvatarFactory.LocalDefault = factory2;
+                    Thread.Sleep(50);
+                    Assert.Same(factory2, AvatarFactory.Default);
+                })
+            );
+
+            Assert.NotSame(factory1, AvatarFactory.Default);
+            Assert.NotSame(factory2, AvatarFactory.Default);
+        }
+
+
 
         public class TestFactory : IAvatarFactory
         {

--- a/src/Avatar.UnitTests/DynamicAvatarFactoryTests.cs
+++ b/src/Avatar.UnitTests/DynamicAvatarFactoryTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Threading.Tasks;
 using Sample;
 using Xunit;
 
@@ -42,6 +43,26 @@ namespace Avatars.UnitTests
             Assert.Throws<NotImplementedException>(() => calculator.Add(2, 3));
 
             Assert.Equal(4, recorder.Invocations.Count);
+        }
+
+        [Fact]
+        public void ConstructorInterceptionNotSupported()
+        {
+            BehaviorPipelineFactory.LocalDefault = new RecordingBehaviorPipelineFactory();
+            AvatarFactory.LocalDefault = new DynamicAvatarFactory();
+
+            var calculator = Avatar.Of<ICalculator>();
+            var avatar = calculator as IAvatar;
+
+            Assert.NotNull(avatar);
+            Assert.Single(avatar.Behaviors);
+            // Cannot record ctor call
+            Assert.Empty(((RecordingBehavior)avatar.Behaviors[0]).Invocations);
+        }
+
+        class RecordingBehaviorPipelineFactory : IBehaviorPipelineFactory
+        {
+            public BehaviorPipeline CreatePipeline<TAvatar>() => new BehaviorPipeline(new RecordingBehavior());
         }
     }
 }

--- a/src/Avatar/AvatarFactory.cs
+++ b/src/Avatar/AvatarFactory.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Threading;
 
 namespace Avatars
 {
@@ -9,13 +10,33 @@ namespace Avatars
     /// </summary>
     public class AvatarFactory : IAvatarFactory
     {
+        static readonly AsyncLocal<IAvatarFactory?> localFactory = new();
         static readonly IAvatarFactory nullFactory = new AvatarFactory();
+        static IAvatarFactory defaultFactory = nullFactory;
 
         /// <summary>
         /// Gets or sets the default <see cref="IAvatarFactory"/> to use 
         /// to create avatars. Defaults to the <see cref="NotImplemented"/> factory.
         /// </summary>
-        public static IAvatarFactory Default { get; set; } = nullFactory;
+        /// <remarks>
+        /// A <see cref="LocalDefault"/> can override the value of this global 
+        /// default, if assigned to a non-null value.
+        /// </remarks>
+        public static IAvatarFactory Default 
+        { 
+            get => localFactory.Value ?? defaultFactory; 
+            set => defaultFactory = value; 
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="IAvatarFactory"/> to use 
+        /// in the current (async) flow, so it does not affect other threads/flows.
+        /// </summary>
+        public static IAvatarFactory? LocalDefault
+        {
+            get => localFactory.Value;
+            set => localFactory.Value = value;
+        }
 
         /// <summary>
         /// A factory that throws <see cref="NotImplementedException"/>.


### PR DESCRIPTION
Adds support for `BehaviorPipelineFactory` and also aligns `AvatarFactory` approach for local default replacement.