### PR TITLE
Make sure breakpoints on scenario source are active in debugging

### DIFF
--- a/src/Avatar.UnitTests/.Scenarios.cs
+++ b/src/Avatar.UnitTests/.Scenarios.cs
@@ -23,7 +23,9 @@ namespace Avatars.UnitTests
         [MemberData(nameof(GetScenarios))]
         public void Run(string path)
         {
-            var (diagnostics, compilation) = GetGeneratedOutput(path);
+            var (diagnostics, compilation) = GetGeneratedOutput(
+                Path.IsPathRooted(path) ? path :
+                Path.Combine(ThisAssembly.Project.MSBuildProjectDirectory, path));
 
             Assert.Empty(diagnostics);
 
@@ -37,8 +39,8 @@ namespace Avatars.UnitTests
         }
 
         public static IEnumerable<object[]> GetScenarios()
-            => Directory.EnumerateFiles("Scenarios", "*.cs")
-                .Select(file => new object[] { file });
+            => Directory.EnumerateFiles(Path.Combine(ThisAssembly.Project.MSBuildProjectDirectory, "Scenarios"), "*.cs")
+                .Select(file => new object[] { Path.Combine("Scenarios", Path.GetFileName(file)) });
 
         static (ImmutableArray<Diagnostic>, Compilation) GetGeneratedOutput(string path)
         {

--- a/src/Avatar.UnitTests/Avatar.UnitTests.csproj
+++ b/src/Avatar.UnitTests/Avatar.UnitTests.csproj
@@ -51,7 +51,7 @@
   <ItemGroup>
     <None Include="CodeAnalysis\ST*\**\*.NoBuild.cs" CopyToOutputDirectory="PreserveNewest" />
     <Compile Remove="CodeAnalysis\ST*\**\*.NoBuild.cs" />
-    <Compile Update="CodeAnalysis\ST*\**\*.cs;Scenarios\**\*.cs" CopyToOutputDirectory="PreserveNewest" />
+    <Compile Update="CodeAnalysis\ST*\**\*.cs" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Avatar.UnitTests/CodeAnalysis/Helpers/WorkspaceHelper.cs
+++ b/src/Avatar.UnitTests/CodeAnalysis/Helpers/WorkspaceHelper.cs
@@ -71,21 +71,19 @@ public static class WorkspaceHelper
 
     public static Assembly Emit(this Compilation compilation, bool symbols = true)
     {
-        using (var stream = new MemoryStream())
-        {
-            var options = symbols ?
-                new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded) :
-                new EmitOptions();
+        using var stream = new MemoryStream();
+        var options = symbols ?
+            new EmitOptions(debugInformationFormat: DebugInformationFormat.Embedded) :
+            new EmitOptions();
 
-            var cts = new CancellationTokenSource(10000);
-            var result = compilation.Emit(stream, 
-                options: options, 
-                cancellationToken: cts.Token);
-            result.AssertSuccess();
+        var cts = new CancellationTokenSource(10000);
+        var result = compilation.Emit(stream,
+            options: options,
+            cancellationToken: cts.Token);
+        result.AssertSuccess();
 
-            stream.Seek(0, SeekOrigin.Begin);
-            return Assembly.Load(stream.ToArray());
-        }
+        stream.Seek(0, SeekOrigin.Begin);
+        return Assembly.Load(stream.ToArray());
     }
 
     public static void AssertSuccess(this EmitResult result)


### PR DESCRIPTION
Previously, because we were loading the CS files from the output directory, the breakpoints set in the actual scenario source were not being picked-up by VS. By loading them from the actual source location in the project, breakpoints Just Work :D