### PR TITLE
Fix some typos

### DIFF
--- a/src/Avatar.DynamicProxy/DynamicAvatarFactory.cs
+++ b/src/Avatar.DynamicProxy/DynamicAvatarFactory.cs
@@ -74,9 +74,9 @@ namespace Avatars
         /// <summary>
         /// Creates the proxy with the <see cref="Generator"/>, using the given default interceptor to implement its behavior.
         /// </summary>
-        protected virtual object CreateProxy(Type baseType, Type[] implementedInterfaces, object[] constructorArguments, ProxyGenerationOptions options, Func<IInterceptor> getDefaultInteceptor)
+        protected virtual object CreateProxy(Type baseType, Type[] implementedInterfaces, object[] constructorArguments, ProxyGenerationOptions options, Func<IInterceptor> getDefaultInterceptor)
             // TODO: bring the approach from https://github.com/moq/moq4/commit/806e9919eab9c1f3879b9e9bda895fa76ecf9d92 for performance.
-            => generator.CreateClassProxy(baseType, implementedInterfaces, options, constructorArguments, getDefaultInteceptor());
+            => generator.CreateClassProxy(baseType, implementedInterfaces, options, constructorArguments, getDefaultInterceptor());
 
         /// <summary>
         /// The <see cref="ProxyGenerator"/> used to create proxy types.

--- a/src/Avatar.StaticProxy/AvatarDocumentGenerator.cs
+++ b/src/Avatar.StaticProxy/AvatarDocumentGenerator.cs
@@ -40,7 +40,7 @@ namespace Avatars
         };
 
         /// <summary>
-        /// Default naming convention used when generating documents, unless overriden 
+        /// Default naming convention used when generating documents, unless overridden
         /// via the corresponding constructor argument.
         /// </summary>
         public static NamingConvention DefaultNamingConvention { get; } = new NamingConvention();

--- a/src/Avatar.UnitTests/.Scenarios.cs
+++ b/src/Avatar.UnitTests/.Scenarios.cs
@@ -76,7 +76,7 @@ namespace Avatars.UnitTests
                 d.Severity == DiagnosticSeverity.Info || 
                 // Type conflicts with referenced assembly, will happen because scenarios 
                 // are also compiled in the unit test project itself, but also in the scenario 
-                // file compilation, but the locally defined in surce wins.
+                // file compilation, but the locally defined in source wins.
                 d.Id == "CS0436");
 
             if (diagnostics.Any())

--- a/src/Avatar.UnitTests/AvatarFactoryTests.cs
+++ b/src/Avatar.UnitTests/AvatarFactoryTests.cs
@@ -62,7 +62,7 @@ namespace Avatars.UnitTests
 
             public TestFactory(object instance) => this.instance = instance;
 
-            public object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] construtorArguments)
+            public object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] constructorArguments)
                 => instance;
         }
     }

--- a/src/Avatar.UnitTests/BehaviorPipelineTests.cs
+++ b/src/Avatar.UnitTests/BehaviorPipelineTests.cs
@@ -394,7 +394,7 @@ namespace Avatars.UnitTests
         }
 
         [Fact]
-        public async Task WhenRunningParalell_ThenCanReplaceLocalPipelineFactory()
+        public async Task WhenRunningParallel_ThenCanReplaceLocalPipelineFactory()
         {
             var factory1 = new TestBehaviorPipelineFactory();
             var factory2 = new TestBehaviorPipelineFactory();

--- a/src/Avatar/AvatarFactory.cs
+++ b/src/Avatar/AvatarFactory.cs
@@ -48,7 +48,7 @@ namespace Avatars
         /// <summary>
         /// See <see cref="IAvatarFactory.CreateAvatar(Assembly, Type, Type[], object[])"/>
         /// </summary>
-        public object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] construtorArguments) 
+        public object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] constructorArguments)
             => throw new NotImplementedException(ThisAssembly.Strings.AvatarFactoryNotImplemented);
     }
 }

--- a/src/Avatar/BehaviorPipeline.cs
+++ b/src/Avatar/BehaviorPipeline.cs
@@ -62,7 +62,7 @@ namespace Avatars
         /// any time, but changes to the list are not visible to in-flight 
         /// invocations. Additionally, the list implements <see cref="INotifyCollectionChanged"/> 
         /// to allow components to monitor changes to the pipeline, as well as <see cref="ISupportInitialize"/> 
-        /// to perform batches of changes to the behaviors and avoid excesive collection change 
+        /// to perform batches of changes to the behaviors and avoid excessive collection change
         /// notifications.
         /// </remarks>
         public IList<IAvatarBehavior> Behaviors { get; }

--- a/src/Avatar/IAvatarFactory.cs
+++ b/src/Avatar/IAvatarFactory.cs
@@ -14,10 +14,10 @@ namespace Avatars
         /// <param name="assembly">Assembly where compile-time generated avatars exist.</param>
         /// <param name="baseType">The base type (or main interface) of the avatar.</param>
         /// <param name="implementedInterfaces">Additional interfaces implemented by the avatar, or an empty array.</param>
-        /// <param name="construtorArguments">
+        /// <param name="constructorArguments">
         /// Constructor arguments if the <paramref name="baseType" /> is a class, rather than an interface, or an empty array.
         /// </param>
         /// <returns>A avatar that implements <see cref="IAvatar"/> in addition to the specified interfaces (if any).</returns>
-		object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] construtorArguments);
+		object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] constructorArguments);
 	}
 }


### PR DESCRIPTION
`construtorArguments` &rarr; `constructorArguments` and `getDefaultInteceptor` &rarr; `getDefaultInterceptor` are the most important corrections since they affect the public API.