### PR TITLE
Normalize indentation (spaces not tabs)

### DIFF
--- a/src/Avatar/AvatarExtensions.cs
+++ b/src/Avatar/AvatarExtensions.cs
@@ -15,7 +15,7 @@ namespace Avatars
         /// <param name="behavior">(invocation, next) => invocation.CreateValueReturn() | invocation.CreateExceptionReturn() | next().Invoke(invocation, next)</param>
         /// <param name="appliesTo">invocation => true|false</param>
         /// <param name="name">Optional friendly name for the behavior.</param>
-		public static IAvatar AddBehavior(this IAvatar avatar, ExecuteDelegate behavior, AppliesToDelegate? appliesTo = null, string? name = null)
+        public static IAvatar AddBehavior(this IAvatar avatar, ExecuteDelegate behavior, AppliesToDelegate? appliesTo = null, string? name = null)
         {
             avatar.Behaviors.Add(new AnonymousBehavior(behavior, appliesTo, name));
             return avatar;
@@ -77,7 +77,7 @@ namespace Avatars
         /// <param name="behavior">(invocation, next) => invocation.CreateValueReturn() | invocation.CreateExceptionReturn() | next().Invoke(invocation, next)</param>
         /// <param name="appliesTo">invocation => true|false</param>
         /// <param name="name">Optional friendly name for the behavior.</param>
-		public static IAvatar InsertBehavior(this IAvatar avatar, int index, ExecuteDelegate behavior, AppliesToDelegate? appliesTo = null, string? name = null)
+        public static IAvatar InsertBehavior(this IAvatar avatar, int index, ExecuteDelegate behavior, AppliesToDelegate? appliesTo = null, string? name = null)
         {
             avatar.Behaviors.Insert(index, new AnonymousBehavior(behavior, appliesTo, name));
             return avatar;

--- a/src/Avatar/IArgumentCollection.cs
+++ b/src/Avatar/IArgumentCollection.cs
@@ -6,7 +6,7 @@ namespace Avatars
     /// <summary>
     /// Represents the arguments of a method invocation.
     /// </summary>
-	public interface IArgumentCollection : IEnumerable<object?>
+    public interface IArgumentCollection : IEnumerable<object?>
     {
         /// <summary>
         /// Whether the collection contains a parameter with the 
@@ -16,22 +16,22 @@ namespace Avatars
         /// </summary>
         /// <param name="name"></param>
         /// <returns></returns>
-		bool Contains(string name);
+        bool Contains(string name);
 
         /// <summary>
         /// Count <see cref="ParameterInfo"/>s in the collection.
         /// </summary>
-		int Count { get; }
+        int Count { get; }
 
         /// <summary>
         /// Get the <see cref="ParameterInfo"/> at the given index.
         /// </summary>
-		ParameterInfo GetInfo(int index);
+        ParameterInfo GetInfo(int index);
 
         /// <summary>
         /// Gets the <see cref="ParameterInfo"/> with the given name.
         /// </summary>
-		ParameterInfo GetInfo(string name);
+        ParameterInfo GetInfo(string name);
 
         /// <summary>
         /// Gets the index of the parameter with the given name or <c>-1</c>
@@ -52,6 +52,6 @@ namespace Avatars
         /// <summary>
         /// Gets or sets the value of the argument at the given index.
         /// </summary>
-		object? this[int index] { get; set; }
-	}
+        object? this[int index] { get; set; }
+    }
 }

--- a/src/Avatar/IAvatar.cs
+++ b/src/Avatar/IAvatar.cs
@@ -12,10 +12,10 @@ namespace Avatars
     [GeneratedCode("Avatar", ThisAssembly.Info.Version)]
     [CompilerGenerated]
     public interface IAvatar
-	{
+    {
         /// <summary>
         /// Behaviors configured for the avatar.
         /// </summary>
-		IList<IAvatarBehavior> Behaviors { get; }
-	}
+        IList<IAvatarBehavior> Behaviors { get; }
+    }
 }

--- a/src/Avatar/IAvatarBehavior.cs
+++ b/src/Avatar/IAvatarBehavior.cs
@@ -3,8 +3,8 @@
     /// <summary>
     /// A configured behavior for an <see cref="IAvatar"/>.
     /// </summary>
-	public interface IAvatarBehavior
-	{
+    public interface IAvatarBehavior
+    {
         /// <summary>
         /// Determines whether the behavior applies to the given 
         /// <see cref="IMethodInvocation"/>.
@@ -19,14 +19,14 @@
         /// <param name="invocation">The current method invocation.</param>
         /// <param name="next">Delegate to invoke the next behavior in the pipeline.</param>
         /// <returns>The result of the method invocation.</returns>
-		IMethodReturn Execute(IMethodInvocation invocation, GetNextBehavior next);
+        IMethodReturn Execute(IMethodInvocation invocation, GetNextBehavior next);
     }
 
     /// <summary>
     /// Method signature for getting the next behavior in a pipeline.
     /// </summary>
     /// <returns>The delegate to invoke the next behavior in a pipeline.</returns>
-	public delegate ExecuteDelegate GetNextBehavior();
+    public delegate ExecuteDelegate GetNextBehavior();
 
     /// <summary>
     /// Method signature for invoking the next behavior in a pipeline.

--- a/src/Avatar/IAvatarFactory.cs
+++ b/src/Avatar/IAvatarFactory.cs
@@ -6,8 +6,8 @@ namespace Avatars
     /// <summary>
     /// Interface implemented by avatar factories.
     /// </summary>
-	public interface IAvatarFactory
-	{
+    public interface IAvatarFactory
+    {
         /// <summary>
         /// Creates a avatar with the given parameters.
         /// </summary>
@@ -18,6 +18,6 @@ namespace Avatars
         /// Constructor arguments if the <paramref name="baseType" /> is a class, rather than an interface, or an empty array.
         /// </param>
         /// <returns>A avatar that implements <see cref="IAvatar"/> in addition to the specified interfaces (if any).</returns>
-		object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] constructorArguments);
-	}
+        object CreateAvatar(Assembly assembly, Type baseType, Type[] implementedInterfaces, object?[] constructorArguments);
+    }
 }

--- a/src/Avatar/IMethodInvocation.cs
+++ b/src/Avatar/IMethodInvocation.cs
@@ -7,28 +7,28 @@ namespace Avatars
     /// <summary>
     /// Represents a method invocation.
     /// </summary>
-	public interface IMethodInvocation : IEquatable<IMethodInvocation>
+    public interface IMethodInvocation : IEquatable<IMethodInvocation>
     {
         /// <summary>
         /// The arguments of the method invocation.
         /// </summary>
-		IArgumentCollection Arguments { get; }
+        IArgumentCollection Arguments { get; }
 
         /// <summary>
         /// An arbitrary property bag used during the invocation.
         /// </summary>
-		IDictionary<string, object> Context { get; }
+        IDictionary<string, object> Context { get; }
 
         /// <summary>
         /// The runtime method being invoked.
         /// </summary>
-		MethodBase MethodBase { get; }
+        MethodBase MethodBase { get; }
 
         /// <summary>
         /// The ultimate target of the method invocation, typically 
         /// a avatar object.
         /// </summary>
-		object Target { get; }
+        object Target { get; }
 
         /// <summary>
         /// Behaviors in the pipeline that should be skipped during this invocation.
@@ -50,6 +50,6 @@ namespace Avatars
         /// </summary>
         /// <param name="exception">The exception to throw from the method invocation.</param>
         /// <returns>The <see cref="IMethodReturn"/> for the current invocation.</returns>
-		IMethodReturn CreateExceptionReturn(Exception exception);
+        IMethodReturn CreateExceptionReturn(Exception exception);
     }
 }

--- a/src/Avatar/IMethodReturn.cs
+++ b/src/Avatar/IMethodReturn.cs
@@ -6,7 +6,7 @@ namespace Avatars
     /// <summary>
     /// Represents the result of invoking a method.
     /// </summary>
-	public interface IMethodReturn
+    public interface IMethodReturn
     {
         /// <summary>
         /// An arbitrary property bag used during the invocation.
@@ -17,7 +17,7 @@ namespace Avatars
         /// Optional exception if the method invocation results in 
         /// an exception being thrown.
         /// </summary>
-		Exception? Exception { get; }
+        Exception? Exception { get; }
 
         /// <summary>
         /// Collection of out/ref arguments.
@@ -28,6 +28,6 @@ namespace Avatars
         /// The value being returned for a non-void method if no exception 
         /// was thrown.
         /// </summary>
-		object? ReturnValue { get; }
-	}
+        object? ReturnValue { get; }
+    }
 }

--- a/src/Avatar/MethodReturn.cs
+++ b/src/Avatar/MethodReturn.cs
@@ -10,53 +10,53 @@ namespace Avatars
     /// Default implementation of <see cref="IMethodReturn"/>.
     /// </summary>
     class MethodReturn : IMethodReturn
-	{
+    {
         readonly IMethodInvocation invocation;
         readonly object?[] allArguments;
 
         public MethodReturn(IMethodInvocation invocation, object? returnValue, object?[] allArguments)
-		{
+        {
             this.invocation = invocation;
             this.allArguments = allArguments;
 
-			ReturnValue = returnValue;
+            ReturnValue = returnValue;
 
-			var outputArgs = new List<object?>();
-			var outputInfos = new List<ParameterInfo>();
-			var allInfos = invocation.MethodBase.GetParameters();
+            var outputArgs = new List<object?>();
+            var outputInfos = new List<ParameterInfo>();
+            var allInfos = invocation.MethodBase.GetParameters();
 
-			for (var i = 0; i < allInfos.Length; i++)
-			{
-				var info = allInfos[i];
-				if (info.ParameterType.IsByRef)
-				{
-					outputArgs.Add(allArguments[i]);
-					outputInfos.Add(info);
-				}
-			}
+            for (var i = 0; i < allInfos.Length; i++)
+            {
+                var info = allInfos[i];
+                if (info.ParameterType.IsByRef)
+                {
+                    outputArgs.Add(allArguments[i]);
+                    outputInfos.Add(info);
+                }
+            }
 
-			Outputs = new ArgumentCollection(outputArgs, outputInfos);
-		}
+            Outputs = new ArgumentCollection(outputArgs, outputInfos);
+        }
 
-		public MethodReturn(IMethodInvocation invocation, Exception exception)
-		{
+        public MethodReturn(IMethodInvocation invocation, Exception exception)
+        {
             this.invocation = invocation;
             allArguments = Array.Empty<object>();
             Outputs = new ArgumentCollection(new object[0], new ParameterInfo[0]);
-			Exception = exception;
-		}
+            Exception = exception;
+        }
 
-		/// <summary>
-		/// The collection of output parameters. If the method has no output
-		/// parameters, this is a zero-length list (never null).
-		/// </summary>
-		public IArgumentCollection Outputs { get; }
+        /// <summary>
+        /// The collection of output parameters. If the method has no output
+        /// parameters, this is a zero-length list (never null).
+        /// </summary>
+        public IArgumentCollection Outputs { get; }
 
-		public object? ReturnValue { get; }
+        public object? ReturnValue { get; }
 
-		public Exception? Exception { get; }
+        public Exception? Exception { get; }
 
-		public IDictionary<string, object> Context { get => invocation.Context; }
+        public IDictionary<string, object> Context { get => invocation.Context; }
 
         /// <summary>
         /// Gets a friendly representation of the object.


### PR DESCRIPTION
Some files accidentally use tabs instead of spaces for indentation.This should fix it.