### PR TITLE
⥱ Ensure compiler matches generator dependencies

### DIFF
--- a/src/Avatar.Package/Avatar.Package.msbuildproj
+++ b/src/Avatar.Package/Avatar.Package.msbuildproj
@@ -22,6 +22,7 @@ service.AddBehavior(...);
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Visible="false" Pack="false" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0" Visible="false" />
     <PackageReference Include="NuGetizer" Version="0.6.0" Visible="false" />
     <PackageReference Update="NuGetizer" Version="42.42.42" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\nugetizer\bin\')" />
   </ItemGroup>

--- a/src/Pack/Pack.props
+++ b/src/Pack/Pack.props
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <ProjectCapability Include="Pack" />
-    <ProjectReference Include="..\**\*.csproj" Exclude="..\**\bin\**\*.*;..\**\obj\**\*.*" />
+    <ProjectReference Include="..\**\*.csproj" Exclude="..\**\bin\**\*.*;..\**\obj\**\*.*;..\**\*Tests.csproj;..\Acceptance\**\*.csproj" />
   </ItemGroup>
   
   <!-- Remove IsPackable=false projects from the globing -->


### PR DESCRIPTION
Given that we pack and depend on some workspace APIs to perform some parts of the code generation, we need the compiler and our workspace dependencies to align. This is trivial to achieve by depending on the toolset that matches our Roslyn version.

This would not be required if we removed all dependencies on workspace APIs.

Fixes #52