### PR TITLE
Rename properties to enable compile-time and run-time avatars

### DIFF
--- a/Avatar.sln
+++ b/Avatar.sln
@@ -11,7 +11,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		src\Directory.Packages.props = src\Directory.Packages.props
 		src\Directory.props = src\Directory.props
 		src\Directory.targets = src\Directory.targets
-		README.md = README.md
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avatar.UnitTests", "src\Avatar.UnitTests\Avatar.UnitTests.csproj", "{766CB6E6-24EF-4CC4-AB05-A45637765838}"

--- a/src/Acceptance/Dynamic/Dynamic.csproj
+++ b/src/Acceptance/Dynamic/Dynamic.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
-    <EnableCompiledAvatars>false</EnableCompiledAvatars>
+    <EnableCompileTimeAvatars>false</EnableCompileTimeAvatars>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Avatar.DynamicProxy/Avatar.DynamicProxy.targets
+++ b/src/Avatar.DynamicProxy/Avatar.DynamicProxy.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition="'$(EnableDynamicAvatars)' != 'false'">
+  <ItemGroup Condition="'$(EnableRunTimeAvatars)' != 'false'">
     <Compile Include="$(MSBuildThisFileDirectory)Avatar.DynamicFactory$(DefaultLanguageSourceExtension)"
              Condition="Exists('$(MSBuildThisFileDirectory)Avatar.DynamicFactory$(DefaultLanguageSourceExtension)')"
              Visible="false" />

--- a/src/Avatar.Package/Avatar.targets
+++ b/src/Avatar.Package/Avatar.targets
@@ -3,25 +3,25 @@
   <!-- If source generators aren't supported, we just won't register the static one -->
   <PropertyGroup>
     <SourceGeneratorSupported Condition="'$(Language)' == 'C#' AND $(MSBuildShortVersion) &gt;= '16.8'">true</SourceGeneratorSupported>
-    <EnableCompiledAvatars Condition="'$(EnableCompiledAvatars)' == '' AND '$(SourceGeneratorSupported)' == 'true'">true</EnableCompiledAvatars>
+    <EnableCompileTimeAvatars Condition="'$(EnableCompileTimeAvatars)' == '' AND '$(SourceGeneratorSupported)' == 'true'">true</EnableCompileTimeAvatars>
   </PropertyGroup>
 
   <PropertyGroup>
     <AvatarAnalyzerDir>$(MSBuildThisFileDirectory)..\..\tools\netstandard2.0</AvatarAnalyzerDir>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(EnableCompiledAvatars)' == 'true'">
+  <ItemGroup Condition="'$(EnableCompileTimeAvatars)' == 'true'">
     <CompilerVisibleProperty Include="DebugSourceGenerators" />
     <CompilerVisibleProperty Include="DebugAvatarGenerator" />
     <CompilerVisibleProperty Include="SkipCompilerExecution" />
     <CompilerVisibleProperty Include="AvatarAnalyzerDir" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(EnableCompiledAvatars)' == 'true' AND '$(SkipCompilerExecution)' != 'true' AND '$(DesignTimeBuild)' != 'true'">
+  <ItemGroup Condition="'$(EnableCompileTimeAvatars)' == 'true' AND '$(SkipCompilerExecution)' != 'true' AND '$(DesignTimeBuild)' != 'true'">
     <Analyzer Include="$(AvatarAnalyzerDir)\Avatar*.dll" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(EnableCompiledAvatars)' == 'true'">
+  <ItemGroup Condition="'$(EnableCompileTimeAvatars)' == 'true'">
     <Compile Include="$(MSBuildThisFileDirectory)Avatar.StaticFactory$(DefaultLanguageSourceExtension)"
              Condition="Exists('$(MSBuildThisFileDirectory)Avatar.StaticFactory$(DefaultLanguageSourceExtension)')"
              Visible="false" />
@@ -35,6 +35,6 @@
   </ItemGroup>
 
   <Import Project="Avatar.DynamicProxy.targets"
-          Condition="'$(EnableCompiledAvatars)' != 'true' AND  Exists('Avatar.DynamicProxy.targets')" />
+          Condition="'$(EnableCompileTimeAvatars)' != 'true' AND  Exists('Avatar.DynamicProxy.targets')" />
 
 </Project>


### PR DESCRIPTION
This makes them more explicit.

Addresses feedback from #48.
Fixes #48.

Thanks @stakx 👍 