### PR TITLE
⚙ Support multiple compiler toolsets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: ⚙ dotnet 5.0
         uses: actions/setup-dotnet@v1
+        if: matrix.os != 'windows-latest'
         with:
           dotnet-version: 5.0.x
 
@@ -113,7 +114,7 @@ jobs:
           path: bin
 
       - name: 🧪 test
-        run: dotnet test -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER" -bl:test.binlog
+        run: dotnet test -p:VersionLabel="$GITHUB_REF.$GITHUB_RUN_NUMBER" -bl:acceptance.binlog
         working-directory: src/Acceptance
 
       - name: 🔼 logs
@@ -121,4 +122,41 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.os }}
+          path: '**/*.binlog'
+
+  preview:
+    defaults:
+      run:
+        shell: pwsh
+    runs-on: windows-latest
+    needs: build
+    steps:
+      - name: 🤘 checkout
+        uses: actions/checkout@v2
+
+      - name: 🔽 packages
+        uses: actions/download-artifact@v2
+        with:
+          name: bin
+          path: bin
+
+      # > VS Preview
+      - name: 🔽 dotnet-vs
+        run: dotnet tool update -g dotnet-vs
+      - name: 🔽 vs preview
+        run: vs install preview --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core	+Microsoft.NetCore.Component.DevelopmentTools
+      - name: ≥ msbuild
+        run: echo "$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin" >> $GITHUB_PATH
+        shell: bash
+      # < VS Preview
+
+      - name: 🧪 test
+        run: msbuild -r -t:build,test -p:TargetFramework=net472 -p:VersionLabel="$($env:GITHUB_REF).$($env:GITHUB_RUN_NUMBER)" -bl:preview.binlog
+        working-directory: src/Acceptance
+
+      - name: 🔼 logs
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: windows-latest
           path: '**/*.binlog'

--- a/Avatar.sln
+++ b/Avatar.sln
@@ -42,6 +42,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".devcontainer", ".devcontai
 EndProject
 Project("{13B669BE-BB05-4DDF-9536-439F39A36129}") = "Pack", "src\Pack\Pack.msbuildproj", "{09AB48C5-E13E-425B-813E-37C2B0416329}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Toolsets", "Toolsets", "{C1AA62FB-A439-4D67-8CE8-3C8CD3D64CCA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avatar.StaticProxy.3.9.0", "src\Avatar.StaticProxy\Avatar.StaticProxy.3.9.0.csproj", "{DCF50EAC-6E65-472E-ADEF-569F7A5CA3B3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -84,6 +88,10 @@ Global
 		{09AB48C5-E13E-425B-813E-37C2B0416329}.Debug|Any CPU.Build.0 = Release|Any CPU
 		{09AB48C5-E13E-425B-813E-37C2B0416329}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{09AB48C5-E13E-425B-813E-37C2B0416329}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DCF50EAC-6E65-472E-ADEF-569F7A5CA3B3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DCF50EAC-6E65-472E-ADEF-569F7A5CA3B3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DCF50EAC-6E65-472E-ADEF-569F7A5CA3B3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DCF50EAC-6E65-472E-ADEF-569F7A5CA3B3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -91,6 +99,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{E1FA02D5-89FF-4C7D-80F1-F94117386637} = {AB748028-AEB8-4CB5-B19F-15E5F92ED71F}
 		{0E7B5D81-4B5E-46D5-8AD1-5F24CF767A55} = {AB748028-AEB8-4CB5-B19F-15E5F92ED71F}
+		{DCF50EAC-6E65-472E-ADEF-569F7A5CA3B3} = {C1AA62FB-A439-4D67-8CE8-3C8CD3D64CCA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5EC1923A-DA53-4C10-99E5-F3862D5F4445}

--- a/samples/Directory.Build.props
+++ b/samples/Directory.Build.props
@@ -1,22 +1,5 @@
 ﻿<Project>
 
-  <Import Project="..\src\Directory.Build.props"/>
+  <Import Project="..\src\Acceptance\Directory.Build.props"/>
 
-  <PropertyGroup>
-    <Nullable>annotations</Nullable>
-    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
-    <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)../bin')">
-      $(MSBuildThisFileDirectory)../bin;
-      https://api.nuget.org/v3/index.json
-    </RestoreSources>
-  </PropertyGroup>
-
-  <!-- Imported early so $(Version) in our references Just Works -->
-  <Import Project="..\src\Directory.Build.targets"/>
-
-  <PropertyGroup Label="Use latest CI build from main"
-                 Condition="!Exists('$(MSBuildThisFileDirectory)../bin')">
-    <VersionSuffix>-main.*</VersionSuffix>
-  </PropertyGroup>
-  
 </Project>

--- a/samples/Directory.Build.targets
+++ b/samples/Directory.Build.targets
@@ -1,0 +1,5 @@
+﻿<Project>
+
+  <Import Project="..\src\Acceptance\Directory.Build.targets"/>
+
+</Project>

--- a/samples/Samples/Samples.csproj
+++ b/samples/Samples/Samples.csproj
@@ -3,16 +3,15 @@
   <PropertyGroup>
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
     <Nullable>enable</Nullable>
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Avatar" Version="$(Version)" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Acceptance/Directory.Build.props
+++ b/src/Acceptance/Directory.Build.props
@@ -3,8 +3,11 @@
   <Import Project="..\Directory.Build.props"/>
   
   <PropertyGroup>
+    <DebugSymbols>true</DebugSymbols>
     <Nullable>annotations</Nullable>
     <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <RestoreSources>
       $(MSBuildThisFileDirectory)../../bin;
       https://api.nuget.org/v3/index.json
@@ -13,5 +16,10 @@
 
   <!-- Imported early so $(Version) in our references Just Works -->
   <Import Project="..\Directory.Build.targets"/>
+
+  <PropertyGroup Label="Use latest CI build from main"
+                 Condition="!Exists('$(MSBuildThisFileDirectory)../../bin')">
+    <VersionSuffix>-main.*</VersionSuffix>
+  </PropertyGroup>
 
 </Project>

--- a/src/Acceptance/Directory.Build.targets
+++ b/src/Acceptance/Directory.Build.targets
@@ -1,7 +1,6 @@
 ﻿<Project>
   
   <!-- Supports the main Avatar Pack project -->
-
   <Target Name="IsPackable" Returns="@(IsPackable)">
     <ItemGroup>
       <IsPackable Include="$(MSBuildProjectFullPath)" IsPackable="false" PackageId="" />

--- a/src/Acceptance/Dynamic.Basic/Dynamic.Basic.vbproj
+++ b/src/Acceptance/Dynamic.Basic/Dynamic.Basic.vbproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Avatar" Version="$(Version)" />
   </ItemGroup>

--- a/src/Acceptance/Dynamic/Dynamic.csproj
+++ b/src/Acceptance/Dynamic/Dynamic.csproj
@@ -9,10 +9,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Avatar" Version="$(Version)" />
     <PackageReference Include="ManualAvatars" Version="$(Version)" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Acceptance/Static/Static.csproj
+++ b/src/Acceptance/Static/Static.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;net5.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.msbuild" Version="2.4.1" Condition="'$(TargetFramework)' == 'net472'" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
     <PackageReference Include="Avatar" Version="$(Version)" />
     <PackageReference Include="ManualAvatars" Version="$(Version)" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Avatar.Package/Avatar.Package.msbuildproj
+++ b/src/Avatar.Package/Avatar.Package.msbuildproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets/2.0.1" DefaultTargets="Pack">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <TargetFrameworkMoniker>.NETStandard,Version=v2.0</TargetFrameworkMoniker>
     <PackageId>Avatar</PackageId>
     <Title>Avatar</Title>
     <Description>Avatars blend with the Na'vi seamlessly, and you can control their behavior precisely ('drive' them) with a psionic link. 
@@ -16,13 +15,11 @@ service.AddBehavior(...);
     <Content Include="Avatar.cs" CodeLanguage="cs" TargetFramework="netstandard2.0" BuildAction="Compile" />
     <Content Include="Avatar.vb" CodeLanguage="vb" TargetFramework="netstandard2.0" BuildAction="Compile" />
     <None Include="Avatar.StaticFactory.*" PackFolder="build\netstandard2.0" />
-    <None Include="Avatar.props" PackFolder="build\netstandard2.0" />
-    <None Include="Avatar.targets" PackFolder="build\netstandard2.0" />
+    <None Include="*.props;*.targets" Exclude="Avatar.Version.props" PackFolder="build\netstandard2.0" />
     <PackageFile Include="@(None)" PackFolder="buildTransitive\netstandard2.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" Visible="false" Pack="false" />
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0" Visible="false" TargetFramework="netstandard2.0" />
     <PackageReference Include="NuGetizer" Version="0.6.0" Visible="false" />
     <PackageReference Update="NuGetizer" Version="42.42.42" Visible="false" Condition="Exists('$(MSBuildThisFileDirectory)..\..\..\nugetizer\bin\')" />
   </ItemGroup>
@@ -31,5 +28,23 @@ service.AddBehavior(...);
     <ProjectReference Include="..\Avatar.CodeAnalysis\Avatar.CodeAnalysis.csproj" AdditionalProperties="IsPackable=false" />
     <ProjectReference Include="..\Avatar.DynamicProxy\Avatar.DynamicProxy.csproj" AdditionalProperties="IsPackable=false" />
     <ProjectReference Include="..\Avatar.StaticProxy\Avatar.StaticProxy.csproj" AdditionalProperties="IsPackable=false" />
+    <ProjectReference Include="..\Avatar.StaticProxy\Avatar.StaticProxy.3.9.0.csproj" AdditionalProperties="IsPackable=false" />
   </ItemGroup>
+  <Target Name="CopyVersion" Inputs="Avatar.Version.props" Outputs="$(IntermediateOutputPath)Avatar.Version.props">
+    <Copy SourceFiles="Avatar.Version.props" DestinationFiles="$(IntermediateOutputPath)Avatar.Version.props" SkipUnchangedFiles="true" />
+  </Target>
+  <Target Name="UpdateVersionProps" DependsOnTargets="CopyVersion" BeforeTargets="GetPackageContents">
+    <!-- Update Avatar.Version.props -->
+    <PropertyGroup>
+      <XmlNs>&lt;Namespace Prefix='msb' Uri='http://schemas.microsoft.com/developer/msbuild/2003'/&gt;</XmlNs>
+    </PropertyGroup>
+    <XmlPoke Namespaces="$(XmlNs)"
+				 XmlInputPath="$(IntermediateOutputPath)Avatar.Version.props"
+				 Query="/msb:Project/msb:PropertyGroup/msb:AvatarVersion"
+				 Value="$(Version)"/>
+    <ItemGroup>
+      <PackageFile Include="$(IntermediateOutputPath)Avatar.Version.props" PackFolder="build\netstandard2.0" />
+      <PackageFile Include="$(IntermediateOutputPath)Avatar.Version.props" PackFolder="buildTransitive\netstandard2.0" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Avatar.Package/Avatar.Version.props
+++ b/src/Avatar.Package/Avatar.Version.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <AvatarVersion>42.42.42</AvatarVersion>
+  </PropertyGroup>
+
+</Project>

--- a/src/Avatar.Package/Avatar.props
+++ b/src/Avatar.Package/Avatar.props
@@ -1,10 +1,14 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
     <AvatarsPublicKey>002400000480000094000000060200000024000052534131000400000100010051155fd0ee280be78d81cc979423f1129ec5dd28edce9cd94fd679890639cad54c121ebdb606f8659659cd313d3b3db7fa41e2271158dd602bb0039a142717117fa1f63d93a2d288a1c2f920ec05c4858d344a45d48ebd31c1368ab783596b382b611d8c92f9c1b3d338296aa21b12f3bc9f34de87756100c172c52a24bad2db</AvatarsPublicKey>
     <AvatarsPublicKeyToken>00352124762f2aa5</AvatarsPublicKeyToken>
 
     <MSBuildShortVersion>$(MSBuildVersion.TrimEnd('0123456789').TrimEnd('.'))</MSBuildShortVersion>
+
+    <AvatarGeneratorLatestRoslyn>3.9.0</AvatarGeneratorLatestRoslyn>
   </PropertyGroup>
+
+  <Import Project="Avatar.Version.props"/>
 
 </Project>

--- a/src/Avatar.Package/Avatar.targets
+++ b/src/Avatar.Package/Avatar.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <!-- If source generators aren't supported, we just won't register the static one -->
   <PropertyGroup>
@@ -6,19 +6,11 @@
     <EnableCompileTimeAvatars Condition="'$(EnableCompileTimeAvatars)' == '' AND '$(SourceGeneratorSupported)' == 'true'">true</EnableCompileTimeAvatars>
   </PropertyGroup>
 
-  <PropertyGroup>
-    <AvatarAnalyzerDir>$(MSBuildThisFileDirectory)..\..\tools\netstandard2.0</AvatarAnalyzerDir>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(EnableCompileTimeAvatars)' == 'true'">
     <CompilerVisibleProperty Include="DebugSourceGenerators" />
     <CompilerVisibleProperty Include="DebugAvatarGenerator" />
     <CompilerVisibleProperty Include="SkipCompilerExecution" />
     <CompilerVisibleProperty Include="AvatarAnalyzerDir" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(EnableCompileTimeAvatars)' == 'true' AND '$(SkipCompilerExecution)' != 'true' AND '$(DesignTimeBuild)' != 'true'">
-    <Analyzer Include="$(AvatarAnalyzerDir)\Avatar*.dll" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(EnableCompileTimeAvatars)' == 'true'">
@@ -34,7 +26,45 @@
     </Compile>
   </ItemGroup>
 
+  <Target Name="ResolveCompileTimeAvatars" BeforeTargets="CoreCompile;GenerateMSBuildEditorConfigFileShouldRun"
+          Condition="'$(EnableCompileTimeAvatars)' == 'true' AND '$(SkipCompilerExecution)' != 'true' AND '$(DesignTimeBuild)' != 'true'">
+
+    <GetRoslynVersion TargetsPath="$(CSharpCoreTargetsPath)">
+      <Output TaskParameter="Version" PropertyName="RoslynVersion" />
+    </GetRoslynVersion>
+
+    <PropertyGroup>
+      <AvatarAnalyzerDir>$([MSBuild]::NormalizePath($(MSBuildThisFileDirectory)..\..\tools\$(RoslynVersion)))</AvatarAnalyzerDir>
+    </PropertyGroup>
+
+    <Error Condition="!Exists($(AvatarAnalyzerDir))" Code="AV001"
+           Text="The current compiler uses Roslyn version $(RoslynVersion) which is not supported yet. Please install package Microsoft.Net.Compilers.Toolset version $(AvatarGeneratorLatestRoslyn) to get the latest supported compiler, or set 'EnableCompileTimeAvatars=false' in the project to switch to run-time avatars." />
+
+    <ItemGroup>
+      <Analyzer Include="$(AvatarAnalyzerDir)\Avatar.StaticProxy.dll" NuGetPackageId="Avatar" NuGetPackageVersion="$(AvatarVersion)" />
+    </ItemGroup>
+
+  </Target>
+
   <Import Project="Avatar.DynamicProxy.targets"
           Condition="'$(EnableCompileTimeAvatars)' != 'true' AND  Exists('Avatar.DynamicProxy.targets')" />
+
+  <UsingTask TaskName="GetRoslynVersion" TaskFactory="RoslynCodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.Core.dll">
+    <ParameterGroup>
+      <TargetsPath />
+      <Version Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Reflection" />
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[
+        // NOTE: we use the tasks assembly because the Microsoft.CodeAnalysis.dll itself has a different location in VS MSBuild and dotnet SDK
+        var name = AssemblyName.GetAssemblyName(Path.Combine(Path.GetDirectoryName(TargetsPath), "Microsoft.Build.Tasks.CodeAnalysis.dll"));
+        Version = name.Version.ToString(2) + ".0";
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
 
 </Project>

--- a/src/Avatar.StaticProxy/Avatar.StaticProxy.3.9.0.csproj
+++ b/src/Avatar.StaticProxy/Avatar.StaticProxy.3.9.0.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- When adding support for a newer Roslyn build, just clone this file and update Avatar.Package\Avatar.props 
+       to set AvatarGeneratorLatestRoslyn to new RoslynVersion in the cloned file.
+       Then add it under the Toolsets solution folder, and add a project reference to it in Avatar.Package.msbuildproj.
+       The RoslynLabel can be used to add support for non-stable versions too.
+  -->
+
+  <PropertyGroup>
+    <AssemblyName>Avatar.StaticProxy</AssemblyName>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RoslynVersion>3.9.0</RoslynVersion>
+    <RoslynLabel>-2.final</RoslynLabel>
+  </PropertyGroup>
+
+  <Import Project="Avatar.StaticProxy.targets"/>
+
+</Project>

--- a/src/Avatar.StaticProxy/Avatar.StaticProxy.csproj
+++ b/src/Avatar.StaticProxy/Avatar.StaticProxy.csproj
@@ -3,43 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <Description>An extensible source generator library for arbitrary avatar (a.k.a. dynamic proxy) code generation at compile-time.</Description>
-    <PackageTags>dotnet roslyn proxy generator</PackageTags>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <RoslynVersion>3.8.0</RoslynVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsPackable)' != 'true'">
-    <PackFolder>tools\$(TargetFramework)</PackFolder>
-    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
-    <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Pack="false" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Pack="false" />
-
-    <PackageReference Include="System.ComponentModel.Composition" Pack="false" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Pack="false" />
-    <PackageReference Include="Microsoft.Bcl.HashCode" Pack="false" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\Avatar\Avatar.csproj" />
-    <ProjectReference Include="..\Avatar.CodeAnalysis\Avatar.CodeAnalysis.csproj" Pack="!$(IsPackable)" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <InternalsVisibleTo Include="Avatar.UnitTests" />
-  </ItemGroup>
-
-  <!-- Replaced by common targets, required for the multitargeting DependsOnTargets below -->
-  <Target Name="ResolveReferences" />
-  <Target Name="AddDependencies" Condition="'$(IsPackable)' != 'true'" AfterTargets="Build" BeforeTargets="GetPackageContents" DependsOnTargets="ResolveReferences">
-    <ItemGroup Condition="'$(TargetFramework)' != ''">
-      <AnalyzerFile Include="@(ReferenceCopyLocalPaths)" Exclude="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.dll' or &#xD;&#xA;                             '%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.CSharp.dll' or &#xD;&#xA;                             '%(Filename)%(Extension)' == 'Microsoft.CodeAnalysisVisualBasic.dll'" Condition="'%(ReferenceCopyLocalPaths.AssetType)' != 'resources'" />
-      <PackageFile Include="@(AnalyzerFile -> '%(FullPath)')" PackagePath="tools\$(TargetFramework)\%(Filename)%(Extension)" />
-    </ItemGroup>
-  </Target>
+  <Import Project="Avatar.StaticProxy.targets"/>
 
 </Project>

--- a/src/Avatar.StaticProxy/Avatar.StaticProxy.targets
+++ b/src/Avatar.StaticProxy/Avatar.StaticProxy.targets
@@ -1,0 +1,55 @@
+﻿<Project>
+
+  <PropertyGroup>
+    <Description>An extensible source generator library for arbitrary avatar (a.k.a. dynamic proxy) code generation at compile-time.</Description>
+    <PackageTags>dotnet roslyn proxy generator</PackageTags>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <!-- When packaged as part of Avatar.Package, we get this property as false so we pack differently as a tool -->
+  <PropertyGroup Condition="'$(IsPackable)' != 'true'">
+    <PackFolder>tools\$(RoslynVersion)</PackFolder>
+    <DisableTransitiveProjectReferences>true</DisableTransitiveProjectReferences>
+    <DisableTransitiveFrameworkReferences>true</DisableTransitiveFrameworkReferences>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Grab versions from Directory.Packages.props for the Core group -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="@(SourceLinkVersion -> '%(Version)')" PrivateAssets="all" />
+    <PackageReference Include="NuGetizer" Version="@(NuGetizerVersion -> '%(Version)')" PrivateAssets="all" />
+    <PackageReference Include="ThisAssembly" Version="@(ThisAssemblyVersion -> '%(Version)')"  PrivateAssets="all" />
+
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="$(RoslynVersion)$(RoslynLabel)" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="$(RoslynVersion)$(RoslynLabel)" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Version="$(RoslynVersion)$(RoslynLabel)" Pack="false" />
+
+    <PackageReference Include="System.ComponentModel.Composition" Version="5.0.0" />
+    <!-- Don't bump these dependencies to 5.0.0 because that breaks net472 source generator runs -->
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" Pack="false" />
+    <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.0" Pack="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Avatar\Avatar.csproj" />
+    <ProjectReference Include="..\Avatar.CodeAnalysis\Avatar.CodeAnalysis.csproj" Pack="!$(IsPackable)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Avatar.UnitTests" />
+  </ItemGroup>
+
+  <!-- Replaced by common targets, required for the multitargeting DependsOnTargets below -->
+  <Target Name="ResolveReferences" />
+  <Target Name="AddDependencies" Condition="'$(IsPackable)' != 'true'" AfterTargets="Build" BeforeTargets="GetPackageContents" DependsOnTargets="ResolveReferences">
+    <ItemGroup Condition="'$(TargetFramework)' != ''">
+      <AnalyzerFile Include="@(ReferenceCopyLocalPaths)" 
+                    Condition="'%(ReferenceCopyLocalPaths.AssetType)' != 'resources'" 
+                    Exclude="'%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.dll' OR 
+                             '%(Filename)%(Extension)' == 'Microsoft.CodeAnalysis.CSharp.dll' OR 
+                             '%(Filename)%(Extension)' == 'Microsoft.CodeAnalysisVisualBasic.dll'" />
+      <PackageFile Include="@(AnalyzerFile -> '%(FullPath)')" PackagePath="tools\$(RoslynVersion)\%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Avatar/Avatar.csproj
+++ b/src/Avatar/Avatar.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.HashCode" />
+    <PackageReference Include="System.ValueTuple" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
     <PackageReference Include="ThisAssembly" PrivateAssets="all" />
     <PackageReference Include="TypeNameFormatter.Sources" PrivateAssets="all" />

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -1,6 +1,6 @@
 <Project>
 
-  <ItemGroup Condition="'$(MSBuildProjectExtension)' != '.msbuildproj'">
+  <ItemGroup Condition="'$(ManagePackageVersionsCentrally)' == 'true'">
     <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all" Visible="false" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="all" Visible="false" />
     <PackageReference Include="NuGetizer" PrivateAssets="all" Visible="false" />
@@ -8,12 +8,18 @@
   </ItemGroup>
 
   <ItemGroup Label="Core">
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <SourceLinkVersion Include="@(PackageVersion -> WithMetadataValue('Identity', 'Microsoft.SourceLink.GitHub'))" />
+
     <PackageVersion Include="ThisAssembly" Version="1.0.3" />
     <PackageVersion Update="ThisAssembly" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')" />
+    <ThisAssemblyVersion Include="@(PackageVersion -> WithMetadataValue('Identity', 'ThisAssembly'))" />
+
     <PackageVersion Include="NuGetizer" Version="0.6.0" />
     <PackageVersion Update="NuGetizer" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')" />
+    <NuGetizerVersion Include="@(PackageVersion -> WithMetadataValue('Identity', 'NuGetizer'))" />
 
     <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
@@ -28,10 +34,12 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.8.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" />
 
-    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
+    <!-- When running under .netframework, this dependency will be needed -->
+    <PackageVersion Include="System.ValueTuple" Version="4.5.0" />
     
     <!-- For packaging purposes -->
     <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="1.1.0" />
 
     <!-- Unit tests need to pack this for tests to run on macOS, for example -->
     <PackageVersion Include="SQLitePCLRaw.bundle_green" Version="2.0.4" />

--- a/src/Directory.props
+++ b/src/Directory.props
@@ -12,6 +12,20 @@
     <TypeNameFormatterInternal>false</TypeNameFormatterInternal>
   </PropertyGroup>
 
+  <!-- We need this in .props so it kicks-in before all the common.props defaulting -->
+  <PropertyGroup Label="Avatar.StaticProxy" Condition="$(MSBuildProjectName.StartsWith('Avatar.StaticProxy'))">
+    <RoslynVersion>$(MSBuildProjectName.Substring(18).TrimStart('.'))</RoslynVersion>
+    <RoslynVersion Condition="'$(RoslynVersion)' == ''">3.8.0</RoslynVersion>
+    <BaseIntermediateOutputPath>obj\$(RoslynVersion)\</BaseIntermediateOutputPath>
+    <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
+    <OutputPath>bin\$(RoslynVersion)\$(Configuration)</OutputPath>
+    <!-- Source generators can only target NS2.0 -->
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <!-- Exclude from one level above the $(BaseIntermediateOutputPath) which is the default in the SDK, 
+         since otherwise we would be including compile artifacts from the other versions. -->
+    <DefaultItemExcludes>$(DefaultItemExcludes);obj/**</DefaultItemExcludes>    
+  </PropertyGroup>
+
   <!-- Will only apply for cross-targeting, will be overriden by common targets typically. 
        This is here for packaging projects only, which upon resolving references from dotnet-nugetize 
        will call GetTargetPath and that would otherwise fail -->

--- a/src/Directory.targets
+++ b/src/Directory.targets
@@ -1,14 +1,5 @@
 <Project>
 
-  <!-- Append $(PackFolder) directory to output and intermediate paths to prevent bin clashes between targets. -->
-  <PropertyGroup Condition="'$(AppendPackFolderToOutputPath)' == 'true' and '$(PackFolder)' != ''">
-    <PackFolderPath>$(PackFolder)</PackFolderPath>
-    <PackFolderPath Condition="'$(TargetFramework)' != ''">$(PackFolderPath.Replace('\$(TargetFramework)', ''))</PackFolderPath>
-    <IntermediateOutputPath>$(IntermediateOutputPath)$(PackFolderPath)\</IntermediateOutputPath>
-    <OutputPath>$(OutputPath)$(PackFolderPath)\</OutputPath>
-    <OutDir>$(OutputPath)</OutDir>
-  </PropertyGroup>
-  
   <Target Name="Test" Condition="@(PackageReference -> WithMetadataValue('Identity', 'xunit')) != ''" DependsOnTargets="GetTargetPath">
     <Exec Command="&quot;$(XunitConsolePath)&quot; &quot;$(TargetPath)&quot;" Condition="'$(UseConsole)' == 'true'" WorkingDirectory="$(MSBuildProjectDirectory)$(OutptuPath)" />
     <xunit Assemblies="$(TargetPath)" Condition="'$(UseConsole)' != 'true'" />


### PR DESCRIPTION
Due to our usage of code fixes and refactorings, we have a (non-public) dependency from the source generator (only used for compile-time avatars in supported configurations, namely C# 9+) to the roslyn workspace API. This dependency doesn't work if at least (so far) major.minor version of Roslyn don't match between the compiler and our generator+deps.

Rather than forcedly switching the compiler in use (like fix for #52 did), we instead make it easy to support multiple toolsets. The goal is to keep at any one time only the publicly supported .NET/VS versions so that our package size doesn't grow too much.

The packaging project was updated to include a new (3.9.0-2.final based) supported toolset for users running VS preview at the time of this commit. An acceptance test verifies the combination against latest VS Preview, so we get early warnings for newer VS preview versions that render our generator incompatible.

In the future, we should explore removing the dependency on workspace, but it's non-trivial amount of work given we'd need to do essentially the same as Override All Members does in VS as well as "Implement Interface/Abstract Class", plus "generate constructors".

Fixes #58.